### PR TITLE
Ww 3132 stripe plugin using incorrect api keys in staging environment

### DIFF
--- a/src/components/Configuration/SettingsEdit.vue
+++ b/src/components/Configuration/SettingsEdit.vue
@@ -1,12 +1,18 @@
 <template>
-    <wwEditorFormRow required label="Public API key">
+    <div v-if="!isEveryKeysSet" class="mb-3 label-sm content-warning flex items-center">
+        <wwEditorIcon class="mr-1" name="warning" small />
+        If not set correctly, staging and editor keys will always use the required production keys.
+    </div>
+    <!-- PROD -->
+    <div class="my-3 label-sm flex items-center">Production</div>
+    <wwEditorFormRow required label="Public prod API key">
         <wwEditorInputText
             placeholder="pk_live_********"
             :model-value="settings.publicData.publicApiKey"
             @update:modelValue="setPublicApiKey"
         />
     </wwEditorFormRow>
-    <wwEditorFormRow required label="Private API key">
+    <wwEditorFormRow required label="Private prod API key">
         <wwEditorInputText
             type="password"
             placeholder="sk_live_********"
@@ -14,14 +20,34 @@
             @update:modelValue="setPrivateApiKey"
         />
     </wwEditorFormRow>
-    <wwEditorFormRow label="Public test API key">
+    <!-- STAGING -->
+    <div class="my-3 label-sm flex items-center">Staging</div>
+    <wwEditorFormRow label="Public staging API key">
+        <wwEditorInputText
+            placeholder="pk_test_********"
+            :model-value="settings.publicData.publicStagingApiKey"
+            tooltip="If not set, the public prod API key will be used."
+            @update:modelValue="setPublicStagingApiKey"
+        />
+    </wwEditorFormRow>
+    <wwEditorFormRow label="Private staging API key">
+        <wwEditorInputText
+            type="password"
+            placeholder="sk_test_********"
+            :model-value="settings.privateData.privateStagingApiKey"
+            @update:modelValue="setPrivateStagingApiKey"
+        />
+    </wwEditorFormRow>
+    <!-- EDITOR -->
+    <div class="my-3 label-sm flex items-center">Editor</div>
+    <wwEditorFormRow label="Public editor API key">
         <wwEditorInputText
             placeholder="pk_test_********"
             :model-value="settings.publicData.publicTestApiKey"
             @update:modelValue="setPublicTestApiKey"
         />
     </wwEditorFormRow>
-    <wwEditorFormRow label="Private test API key">
+    <wwEditorFormRow label="Private editor API key">
         <wwEditorInputText
             type="password"
             placeholder="sk_test_********"
@@ -38,14 +64,20 @@ export default {
     },
     emits: ['update:settings'],
     methods: {
+        reloadPlugin() {
+            this.plugin.load(
+                this.settings.publicData.publicTestApiKey ||
+                    this.settings.publicData.publicStagingApiKey ||
+                    this.settings.publicData.publicApiKey
+            );
+        },
+        // used in prod
         setPublicApiKey(publicApiKey) {
             this.$emit('update:settings', {
                 ...this.settings,
                 publicData: { ...this.settings.publicData, publicApiKey },
             });
-            this.$nextTick(() =>
-                this.plugin.load(this.settings.publicData.publicTestApiKey || this.settings.publicData.publicApiKey)
-            );
+            this.$nextTick(() => this.reloadPlugin());
         },
         setPrivateApiKey(privateApiKey) {
             this.$emit('update:settings', {
@@ -53,20 +85,45 @@ export default {
                 privateData: { ...this.settings.privateData, privateApiKey },
             });
         },
+        // used in staging
+        setPublicStagingApiKey(publicStagingApiKey) {
+            this.$emit('update:settings', {
+                ...this.settings,
+                publicData: { ...this.settings.publicData, publicStagingApiKey },
+            });
+            this.$nextTick(() => this.reloadPlugin());
+        },
+        setPrivateStagingApiKey(privateStagingApiKey) {
+            this.$emit('update:settings', {
+                ...this.settings,
+                privateData: { ...this.settings.privateData, privateStagingApiKey },
+            });
+        },
+        // used in editor
         setPublicTestApiKey(publicTestApiKey) {
             this.$emit('update:settings', {
                 ...this.settings,
                 publicData: { ...this.settings.publicData, publicTestApiKey },
             });
-            this.$nextTick(() =>
-                this.plugin.load(this.settings.publicData.publicTestApiKey || this.settings.publicData.publicApiKey)
-            );
+            this.$nextTick(() => this.reloadPlugin());
         },
         setPrivateTestApiKey(privateTestApiKey) {
             this.$emit('update:settings', {
                 ...this.settings,
                 privateData: { ...this.settings.privateData, privateTestApiKey },
             });
+        },
+    },
+    computed: {
+        isEveryKeysSet() {
+            return (
+                this.settings.publicData.publicApiKey &&
+                this.settings.privateData.privateApiKey &&
+                this.settings.publicData.publicStagingApiKey &&
+                this.settings.privateData.privateStagingApiKey &&
+                this.settings.publicData.publicTestApiKey &&
+                this.settings.privateData.privateTestApiKey
+            );
         },
     },
 };

--- a/src/components/Configuration/SettingsEdit.vue
+++ b/src/components/Configuration/SettingsEdit.vue
@@ -1,18 +1,18 @@
 <template>
     <div v-if="!isEveryKeysSet" class="mb-3 label-sm content-warning flex items-center">
         <wwEditorIcon class="mr-1" name="warning" small />
-        If not set correctly, staging and editor keys will always use the required production keys.
+        STAGING and EDITOR use PRODUCTION keys if empty
     </div>
     <!-- PROD -->
     <div class="my-3 label-sm flex items-center">Production</div>
-    <wwEditorFormRow required label="Public prod API key">
+    <wwEditorFormRow required label="Public API key">
         <wwEditorInputText
             placeholder="pk_live_********"
             :model-value="settings.publicData.publicApiKey"
             @update:modelValue="setPublicApiKey"
         />
     </wwEditorFormRow>
-    <wwEditorFormRow required label="Private prod API key">
+    <wwEditorFormRow required label="Private API key">
         <wwEditorInputText
             type="password"
             placeholder="sk_live_********"
@@ -22,15 +22,14 @@
     </wwEditorFormRow>
     <!-- STAGING -->
     <div class="my-3 label-sm flex items-center">Staging</div>
-    <wwEditorFormRow label="Public staging API key">
+    <wwEditorFormRow label="Public API key">
         <wwEditorInputText
             placeholder="pk_test_********"
             :model-value="settings.publicData.publicStagingApiKey"
-            tooltip="If not set, the public prod API key will be used."
             @update:modelValue="setPublicStagingApiKey"
         />
     </wwEditorFormRow>
-    <wwEditorFormRow label="Private staging API key">
+    <wwEditorFormRow label="Private API key">
         <wwEditorInputText
             type="password"
             placeholder="sk_test_********"
@@ -40,14 +39,14 @@
     </wwEditorFormRow>
     <!-- EDITOR -->
     <div class="my-3 label-sm flex items-center">Editor</div>
-    <wwEditorFormRow label="Public editor API key">
+    <wwEditorFormRow label="Public API key">
         <wwEditorInputText
             placeholder="pk_test_********"
             :model-value="settings.publicData.publicTestApiKey"
             @update:modelValue="setPublicTestApiKey"
         />
     </wwEditorFormRow>
-    <wwEditorFormRow label="Private editor API key">
+    <wwEditorFormRow label="Private API key">
         <wwEditorInputText
             type="password"
             placeholder="sk_test_********"

--- a/src/components/Configuration/SettingsSummary.vue
+++ b/src/components/Configuration/SettingsSummary.vue
@@ -1,28 +1,54 @@
 <template>
-    <wwEditorFormRow label="Public API key">
+    <!-- PROD -->
+    <div class="my-3 label-sm flex items-center">Production</div>
+    <wwEditorFormRow label="Public prod API key">
         <div class="flex items-center body-2">
             <wwEditorIcon name="key" class="mr-2" />
             <div class="text-ellipsis">{{ settings.publicData.publicApiKey || 'not defined' }}</div>
         </div>
     </wwEditorFormRow>
-    <wwEditorFormRow label="Private API key">
+    <wwEditorFormRow label="Private prod API key">
         <div class="flex items-center body-2">
             <wwEditorIcon name="key" class="mr-2" />
             <div class="text-ellipsis">{{ privateApiKey || 'not defined' }}</div>
         </div>
     </wwEditorFormRow>
-    <wwEditorFormRow label="Public test API key" v-if="settings.publicData.publicTestApiKey">
+    <!-- STAGING -->
+    <div class="my-3 label-sm flex items-center">Staging</div>
+    <wwEditorFormRow label="Public staging API key" v-if="isStagingConfigValid">
+        <div class="flex items-center body-2">
+            <wwEditorIcon name="key" class="mr-2" />
+            <div class="text-ellipsis">{{ settings.publicData.publicStagingApiKey }}</div>
+        </div>
+    </wwEditorFormRow>
+    <wwEditorFormRow label="Private staging API key" v-if="isStagingConfigValid">
+        <div class="flex items-center body-2">
+            <wwEditorIcon name="key" class="mr-2" />
+            <div class="text-ellipsis">{{ privateStagingApiKey }}</div>
+        </div>
+    </wwEditorFormRow>
+    <div class="mb-3 label-sm content-warning flex items-center" v-if="!isStagingConfigValid">
+        <wwEditorIcon class="mr-1" name="warning" small />
+        Staging key pair is not set, the production key will be used in staging.
+    </div>
+    <!-- EDITOR -->
+    <div class="my-3 label-sm flex items-center">Editor</div>
+    <wwEditorFormRow label="Public editor API key" v-if="isEditorConfigValid">
         <div class="flex items-center body-2">
             <wwEditorIcon name="key" class="mr-2" />
             <div class="text-ellipsis">{{ settings.publicData.publicTestApiKey }}</div>
         </div>
     </wwEditorFormRow>
-    <wwEditorFormRow label="Private test API key" v-if="privateTestApiKey">
+    <wwEditorFormRow label="Private editor API key" v-if="isEditorConfigValid">
         <div class="flex items-center body-2">
             <wwEditorIcon name="key" class="mr-2" />
             <div class="text-ellipsis">{{ privateTestApiKey }}</div>
         </div>
     </wwEditorFormRow>
+    <div class="mb-3 label-sm content-warning flex items-center" v-if="!isEditorConfigValid">
+        <wwEditorIcon class="mr-1" name="warning" small />
+        Test key pair is not set, the production key will be used in the editor.
+    </div>
 </template>
 
 <script>
@@ -31,11 +57,26 @@ export default {
         settings: { type: Object, required: true },
     },
     computed: {
+        // used in prod
         privateApiKey() {
             return (this.settings.privateData.privateApiKey || '').replace(/./g, '*');
         },
+        // used in staging
+        privateStagingApiKey() {
+            return (this.settings.privateData.privateStagingApiKey || '').replace(/./g, '*');
+        },
+        // used in editor
         privateTestApiKey() {
             return (this.settings.privateData.privateTestApiKey || '').replace(/./g, '*');
+        },
+        isProdConfigValid() {
+            return this.settings.publicData.publicApiKey && this.settings.privateData.privateApiKey;
+        },
+        isStagingConfigValid() {
+            return this.settings.publicData.publicStagingApiKey && this.settings.privateData.privateStagingApiKey;
+        },
+        isEditorConfigValid() {
+            return this.settings.publicData.publicTestApiKey && this.settings.privateData.privateTestApiKey;
         },
     },
 };

--- a/src/components/Configuration/SettingsSummary.vue
+++ b/src/components/Configuration/SettingsSummary.vue
@@ -27,9 +27,16 @@
             <div class="text-ellipsis">{{ privateStagingApiKey }}</div>
         </div>
     </wwEditorFormRow>
-    <div class="mb-3 label-sm content-warning flex items-center" v-if="!isStagingConfigValid">
+    <div class="mb-3 body-sm content-warning flex items-center" v-if="isStagingConfigNotSet">
+        Not set => Production keys used in staging.
+    </div>
+    <div class="mb-3 label-sm content-alert flex items-center" v-if="isStagingConfigBroken">
         <wwEditorIcon class="mr-1" name="warning" small />
-        Staging key pair is not set, the production key will be used in staging.
+        {{
+            privateStagingApiKey
+                ? 'Private key is set but not public => Possible issues in staging.'
+                : 'Public key is set but not private => Possible issues in staging.'
+        }}
     </div>
     <!-- EDITOR -->
     <div class="my-3 label-sm flex items-center">Editor</div>
@@ -41,13 +48,19 @@
     </wwEditorFormRow>
     <wwEditorFormRow label="Private editor API key" v-if="isEditorConfigValid">
         <div class="flex items-center body-2">
-            <wwEditorIcon name="key" class="mr-2" />
             <div class="text-ellipsis">{{ privateTestApiKey }}</div>
         </div>
     </wwEditorFormRow>
-    <div class="mb-3 label-sm content-warning flex items-center" v-if="!isEditorConfigValid">
+    <div class="mb-3 body-sm content-warning flex items-center" v-if="isEditorConfigNotSet">
+        Not set => Production keys used in the editor.
+    </div>
+    <div class="mb-3 label-sm content-alert flex items-center" v-if="isEditorConfigBroken">
         <wwEditorIcon class="mr-1" name="warning" small />
-        Test key pair is not set, the production key will be used in the editor.
+        {{
+            privateTestApiKey
+                ? 'Private key is set but not public => Possible issues in editor.'
+                : 'Public key is set but not private => Possible issues in editor.'
+        }}
     </div>
 </template>
 
@@ -69,6 +82,7 @@ export default {
         privateTestApiKey() {
             return (this.settings.privateData.privateTestApiKey || '').replace(/./g, '*');
         },
+
         isProdConfigValid() {
             return this.settings.publicData.publicApiKey && this.settings.privateData.privateApiKey;
         },
@@ -77,6 +91,29 @@ export default {
         },
         isEditorConfigValid() {
             return this.settings.publicData.publicTestApiKey && this.settings.privateData.privateTestApiKey;
+        },
+
+        isProdConfigNotSet() {
+            return !this.settings.publicData.publicApiKey && !this.settings.privateData.privateApiKey;
+        },
+        isStagingConfigNotSet() {
+            return !this.settings.publicData.publicStagingApiKey && !this.settings.privateData.privateStagingApiKey;
+        },
+        isEditorConfigNotSet() {
+            return !this.settings.publicData.publicTestApiKey && !this.settings.privateData.privateTestApiKey;
+        },
+
+        isStagingConfigBroken() {
+            return (
+                (this.settings.publicData.publicStagingApiKey && !this.settings.privateData.privateStagingApiKey) ||
+                (!this.settings.publicData.publicStagingApiKey && this.settings.privateData.privateStagingApiKey)
+            );
+        },
+        isEditorConfigBroken() {
+            return (
+                (this.settings.publicData.publicTestApiKey && !this.settings.privateData.privateTestApiKey) ||
+                (!this.settings.publicData.publicTestApiKey && this.settings.privateData.privateTestApiKey)
+            );
         },
     },
 };


### PR DESCRIPTION
⚠️ Un PR sur weweb-plugins pour pouvoir prendre en compte les clés de staging

- Ajout de la possibilité d'avoir une clé en staging
- Ajout de messages de warning et alert si le plug in est mal configuré (une clé private manquante et public set par ex)
- Ajout d'info pour préciser l'utilisation de la clé prod si staging/editor pas set